### PR TITLE
Add px optimize command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "ext-zip": "*",
     "civicrm/composer-downloads-plugin": "^2.1 || ^3.0",
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
+    "mikey179/vfsstream": "^1.6",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "phpcompatibility/php-compatibility": "^9",
     "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",

--- a/src/Cli/Command/Optimize.php
+++ b/src/Cli/Command/Optimize.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PageExperience\Cli\Command;
+
+use AmpProject\Cli\Command;
+use AmpProject\Cli\Options;
+use AmpProject\Optimizer\ErrorCollection;
+use AmpProject\Exception\Cli\InvalidArgument;
+use AmpProject\Optimizer\TransformationEngine;
+
+/**
+ * Commands that deal with the AMP optimizer.
+ *
+ * @package ampproject/px-toolbox
+ */
+final class Optimize extends Command
+{
+    /**
+     * Name of the command.
+     *
+     * @var string
+     */
+    const NAME = 'optimize';
+
+    /**
+     * Help text of the command.
+     *
+     * @var string
+     */
+    const HELP_TEXT = 'Run a file or HTML through the AMP Optimizer.';
+
+    /**
+     * Register the command.
+     *
+     * @param Options $options Options instance to register the command with.
+     */
+    public function register(Options $options)
+    {
+        $options->registerCommand(self::NAME, self::HELP_TEXT);
+
+        $options->registerArgument(
+            'file',
+            "Input file to run through the AMP Optimizer. Omit or use '-' to read from STDIN.",
+            false,
+            self::NAME
+        );
+    }
+
+    /**
+     * Process the command.
+     *
+     * @param Options $options Options instance to process the command with.
+     *
+     * @throws InvalidArgument If the provided file is not readable.
+     */
+    public function process(Options $options)
+    {
+        $args = $options->getArguments();
+
+        $file = '-';
+
+        if (count($args) > 0) {
+            $file = array_shift($args);
+        }
+
+        if ($file !== '-' && (! is_file($file) || ! is_readable($file))) {
+            throw InvalidArgument::forUnreadableFile($file);
+        }
+
+        if ($file === '-') {
+            $file = 'php://stdin';
+        }
+
+        $html                  = file_get_contents($file);
+        $errors                = new ErrorCollection();
+        $transformation_engine = new TransformationEngine();
+        $optimized_html        = $transformation_engine->optimizeHtml($html, $errors);
+
+        fwrite(STDOUT, $optimized_html);
+
+        /** @var Error $error */
+        foreach ($errors as $error) {
+            $this->cli->warning("[{$error->getCode()}] {$error->getMessage()}");
+        }
+    }
+}

--- a/src/Cli/Command/Optimize.php
+++ b/src/Cli/Command/Optimize.php
@@ -34,6 +34,7 @@ final class Optimize extends Command
      * Register the command.
      *
      * @param Options $options Options instance to register the command with.
+     * @return void
      */
     public function register(Options $options)
     {
@@ -51,6 +52,7 @@ final class Optimize extends Command
      * Process the command.
      *
      * @param Options $options Options instance to process the command with.
+     * @return void
      *
      * @throws InvalidArgument If the provided file is not readable.
      */
@@ -72,7 +74,12 @@ final class Optimize extends Command
             $file = 'php://stdin';
         }
 
-        $html           = file_get_contents($file);
+        $html = file_get_contents($file);
+
+        if ($html === false) {
+            return;
+        }
+
         $engine         = new Engine(ConfiguredStubbedRemoteGetRequest::create());
         $profile        = new ConfigurationProfile();
         $optimized_html = $engine->optimizeHtml($html, $profile);

--- a/src/Cli/Command/Optimize.php
+++ b/src/Cli/Command/Optimize.php
@@ -2,11 +2,12 @@
 
 namespace PageExperience\Cli\Command;
 
+use PageExperience\Engine;
 use AmpProject\Cli\Command;
 use AmpProject\Cli\Options;
-use AmpProject\Optimizer\ErrorCollection;
 use AmpProject\Exception\Cli\InvalidArgument;
-use AmpProject\Optimizer\TransformationEngine;
+use PageExperience\Engine\ConfigurationProfile;
+use PageExperience\Tests\ConfiguredStubbedRemoteGetRequest;
 
 /**
  * Commands that deal with the AMP optimizer.
@@ -71,16 +72,13 @@ final class Optimize extends Command
             $file = 'php://stdin';
         }
 
-        $html                  = file_get_contents($file);
-        $errors                = new ErrorCollection();
-        $transformation_engine = new TransformationEngine();
-        $optimized_html        = $transformation_engine->optimizeHtml($html, $errors);
+        $html           = file_get_contents($file);
+        $engine         = new Engine(ConfiguredStubbedRemoteGetRequest::create());
+        $profile        = new ConfigurationProfile();
+        $optimized_html = $engine->optimizeHtml($html, $profile);
 
         fwrite(STDOUT, $optimized_html);
 
-        /** @var Error $error */
-        foreach ($errors as $error) {
-            $this->cli->warning("[{$error->getCode()}] {$error->getMessage()}");
-        }
+        // TODO: Display errors collected by the ErrorCollection in AmpOptimizer::optimizeHtml.
     }
 }

--- a/src/Cli/Command/Optimize.php
+++ b/src/Cli/Command/Optimize.php
@@ -10,7 +10,7 @@ use PageExperience\Engine\ConfigurationProfile;
 use PageExperience\Tests\ConfiguredStubbedRemoteGetRequest;
 
 /**
- * Commands that deal with the AMP optimizer.
+ * Commands that deal with the PX Engine Optimizer.
  *
  * @package ampproject/px-toolbox
  */
@@ -28,7 +28,7 @@ final class Optimize extends Command
      *
      * @var string
      */
-    const HELP_TEXT = 'Run a file or HTML through the AMP Optimizer.';
+    const HELP_TEXT = 'Run a file or a string of HTML through the PX Engine Optimizer.';
 
     /**
      * Register the command.
@@ -42,7 +42,7 @@ final class Optimize extends Command
 
         $options->registerArgument(
             'file',
-            "Input file to run through the AMP Optimizer. Omit or use '-' to read from STDIN.",
+            "Input file to run through the PX Engine Optimizer. Omit or use '-' to read from STDIN.",
             false,
             self::NAME
         );
@@ -85,7 +85,5 @@ final class Optimize extends Command
         $optimizedHtml  = $engine->optimizeHtml($html, $profile);
 
         echo($optimizedHtml . PHP_EOL);
-
-        // TODO: Display errors collected by the ErrorCollection in AmpOptimizer::optimizeHtml.
     }
 }

--- a/src/Cli/Command/Optimize.php
+++ b/src/Cli/Command/Optimize.php
@@ -82,9 +82,9 @@ final class Optimize extends Command
 
         $engine         = new Engine(ConfiguredStubbedRemoteGetRequest::create());
         $profile        = new ConfigurationProfile();
-        $optimized_html = $engine->optimizeHtml($html, $profile);
+        $optimizedHtml  = $engine->optimizeHtml($html, $profile);
 
-        fwrite(STDOUT, $optimized_html);
+        echo($optimizedHtml . PHP_EOL);
 
         // TODO: Display errors collected by the ErrorCollection in AmpOptimizer::optimizeHtml.
     }

--- a/src/Cli/PxExecutable.php
+++ b/src/Cli/PxExecutable.php
@@ -22,6 +22,7 @@ final class PxExecutable extends Executable
      */
     const COMMAND_CLASSES = [
         PxCommand\Analyze::class,
+        PxCommand\Optimize::class,
         PxCommand\PageSpeedInsights::class,
     ];
 

--- a/tests/src/Cli/OptimizeTest.php
+++ b/tests/src/Cli/OptimizeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PageExperience\Tests\Cli;
+
+use AmpProject\Cli\Command;
+use AmpProject\Cli\Executable;
+use AmpProject\Cli\Options;
+use org\bovigo\vfs\vfsStream;
+use PageExperience\Cli\Command\Optimize;
+use PageExperience\Tests\TestCase;
+use AmpProject\Exception\Cli\InvalidArgument;
+
+/**
+ * Test the PageExperience\Cli\Command\Optimize class.
+ *
+ * @package ampproject/px-toolbox-php
+ */
+final class OptimizeTest extends TestCase
+{
+    public function testInstantiation()
+    {
+        $executable = $this->createMock(Executable::class);
+
+        $command = new Optimize($executable);
+
+        $this->assertInstanceOf(Command::class, $command);
+        $this->assertEquals('optimize', $command->getName());
+    }
+
+    public function testRegistration()
+    {
+        $executable = $this->createMock(Executable::class);
+        $options    = $this->createMock(Options::class);
+        $options->expects($this->once())
+                ->method('registerCommand')
+                ->with($this->equalTo('optimize'));
+        $options->expects($this->once())
+                ->method('registerArgument')
+                ->with($this->equalTo('file'));
+
+        $command = new Optimize($executable);
+        $command->register($options);
+    }
+
+    public function testProcessing()
+    {
+        $root = vfsStream::setup();
+        $file = vfsStream::newFile('input.html')
+            ->withContent('<amp-img src="image.jpg" width="500" height="500">')
+            ->at($root);
+
+        $executable = $this->createMock(Executable::class);
+        $options    = $this->createMock(Options::class);
+
+        $command = new Optimize($executable);
+        $command->register($options);
+        $options->expects($this->once())
+                ->method('getArguments')
+                ->willReturn([$file->url()]);
+
+        ob_start();
+        $command->process($options);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('transformed="self;v=1"', $output);
+    }
+
+    public function testUnreadableFileThrowsError()
+    {
+        $root = vfsStream::setup();
+        $file = vfsStream::newFile('input.html')->at($root)->chmod(000);
+
+        $executable = $this->createMock(Executable::class);
+        $options    = $this->createMock(Options::class);
+
+        $command = new Optimize($executable);
+        $command->register($options);
+        $options->expects($this->once())
+                ->method('getArguments')
+                ->willReturn([$file->url()]);
+
+        $this->expectException(InvalidArgument::class);
+
+        $command->process($options);
+    }
+}

--- a/tests/src/Cli/OptimizeTest.php
+++ b/tests/src/Cli/OptimizeTest.php
@@ -5,15 +5,15 @@ namespace PageExperience\Tests\Cli;
 use AmpProject\Cli\Command;
 use AmpProject\Cli\Executable;
 use AmpProject\Cli\Options;
+use AmpProject\Exception\Cli\InvalidArgument;
 use org\bovigo\vfs\vfsStream;
 use PageExperience\Cli\Command\Optimize;
 use PageExperience\Tests\TestCase;
-use AmpProject\Exception\Cli\InvalidArgument;
 
 /**
  * Test the PageExperience\Cli\Command\Optimize class.
  *
- * @package ampproject/px-toolbox-php
+ * @package ampproject/px-toolbox
  */
 final class OptimizeTest extends TestCase
 {


### PR DESCRIPTION
This PR adds a new command `px optimize`. It takes a filepath or a string of HTML via STDIN to optimize, and outputs the optimized result to STDOUT.

Usage,
```
px optimize path/to/file.html
// or
echo '<amp-img src="image.jpg" width="500" height="500">' | px optimize
```

Closes #3 