### PR TITLE
Add test cases for the event dispatcher subsystem

### DIFF
--- a/tests/Engine/EventDispatcher/BaseEventDispatcherTest.php
+++ b/tests/Engine/EventDispatcher/BaseEventDispatcherTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PageExperience\Tests\Engine\EventDispatcher;
+
+use PageExperience\Engine\Event;
+use PageExperience\Tests\TestCase;
+use PageExperience\Engine\StoppableEvent;
+use PageExperience\Engine\ListenerProvider;
+use PageExperience\Engine\EventDispatcher\BaseEventDispatcher;
+
+/**
+ * Test the BaseEventDispatcher class.
+ *
+ * @package ampproject/px-toolbox-php
+ */
+final class BaseEventDispatcherTest extends TestCase
+{
+    /**
+     * Test the class instance.
+     */
+    public function testItCanBeInstantiated()
+    {
+        $listenProvider  = $this->createMock(ListenerProvider::class);
+        $eventDispatcher = new BaseEventDispatcher($listenProvider);
+
+        self::assertInstanceOf(BaseEventDispatcher::class, $eventDispatcher);
+    }
+
+    /**
+     * Test dispatching a StoppableEvent which is stopped propagating.
+     */
+    public function testDispatchingStoppableEvent()
+    {
+        $event           = $this->createMock(StoppableEvent::class);
+        $listenProvider  = $this->createMock(ListenerProvider::class);
+        $eventDispatcher = new BaseEventDispatcher($listenProvider);
+
+        $event->method('isPropagationStopped')->willReturn(true);
+
+        $event = $eventDispatcher->dispatch($event);
+
+        self::assertInstanceOf(StoppableEvent::class, $event);
+    }
+
+    /**
+     * Test dispatching a StoppableEvent which is still propagating.
+     */
+    public function testDispatchingStoppableEventStillPropagating()
+    {
+        $event           = $this->createMock(StoppableEvent::class);
+        $listenProvider  = $this->createMock(ListenerProvider::class);
+        $eventDispatcher = new BaseEventDispatcher($listenProvider);
+
+        $event->method('isPropagationStopped')->willReturn(false);
+        $listenProvider->method('getListenersForEvent')->willReturn([function () {}]);
+
+        $event = $eventDispatcher->dispatch($event);
+
+        self::assertInstanceOf(StoppableEvent::class, $event);
+    }
+
+    /**
+     * Test dispatching a regular Event.
+     */
+    public function testDispatchingEventToEventListener()
+    {
+        $event           = $this->createMock(Event::class);
+        $listenProvider  = $this->createMock(ListenerProvider::class);
+        $eventDispatcher = new BaseEventDispatcher($listenProvider);
+
+        $listenProvider->method('getListenersForEvent')->willReturn([function () {}]);
+
+        $event = $eventDispatcher->dispatch($event);
+
+        self::assertInstanceOf(Event::class, $event);
+    }
+}

--- a/tests/Engine/EventDispatcher/BaseListenerProviderTest.php
+++ b/tests/Engine/EventDispatcher/BaseListenerProviderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace PageExperience\Tests\Engine\EventDispatcher;
+
+use PageExperience\Engine\Event;
+use PageExperience\Tests\TestCase;
+use PageExperience\Engine\EventDispatcher\BaseListenerProvider;
+
+/**
+ * Test the BaseListenerProvider class.
+ *
+ * @package ampproject/px-toolbox-php
+ */
+final class BaseListenerProviderTest extends TestCase
+{
+    /**
+     * Test the class instance.
+     */
+    public function testItCanBeInstantiated()
+    {
+        $eventListener = new BaseListenerProvider();
+
+        self::assertInstanceOf(BaseListenerProvider::class, $eventListener);
+    }
+
+    /**
+     * Test basic add, get and clear event operations.
+     */
+    public function testBasicOperations()
+    {
+        $eventListener = new BaseListenerProvider();
+        $event         = $this->createMock(Event::class);
+        $eventType     = get_class($event);
+
+        $listeners = $eventListener->getListenersForEvent($event);
+        self::assertEquals([], $listeners);
+
+        $eventListener->addListener($eventType, function () {} );
+        $eventListener->addListener($eventType, function () {} );
+
+        $listeners = $eventListener->getListenersForEvent($event);
+        self::assertIsArray($listeners);
+        self::assertCount(2, $listeners);
+
+        $eventListener->clearListeners($eventType);
+        $listeners = $eventListener->getListenersForEvent($event);
+        self::assertEquals([], $listeners);
+    }
+}

--- a/tests/Engine/EventDispatcher/StoppablePropagationTest.php
+++ b/tests/Engine/EventDispatcher/StoppablePropagationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PageExperience\Tests\Engine\EventDispatcher;
+
+use PageExperience\Tests\TestCase;
+use PageExperience\Engine\EventDispatcher\StoppablePropagation;
+
+/**
+ * Test the StoppablePropagationTest class.
+ *
+ * @package ampproject/px-toolbox-php
+ */
+final class StoppablePropagationTest extends TestCase
+{
+    /**
+     * Test propagation status.
+     */
+    public function testPropagationStatus()
+    {
+        /** @var StoppablePropagation **/
+        $mock = $this->getMockForTrait(StoppablePropagation::class);
+
+        self::assertFalse($mock->isPropagationStopped());
+
+        $mock->stopPropagation();
+        self::assertTrue($mock->isPropagationStopped());
+    }
+}


### PR DESCRIPTION
This PR adds the missing tests for the event dispatcher subsystem. Tests added for the following classes:

- `\PageExperience\Engine\EventDispatcher\BaseEventDispatcher`
- `\PageExperience\Engine\EventDispatcher\BaseListenerProvider`
- `\PageExperience\Engine\EventDispatcher\StoppablePropagation` 

Fixes #4 