### PR TITLE
Fix EngineTest fail test case

### DIFF
--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -73,7 +73,7 @@ final class EngineTest extends TestCase
         $optimizedResponseCallback = function (...$arguments) {
             $optimizedResponse = $this->createMock(ResponseInterface::class);
             $optimizedResponse->method('getBody')
-                              ->willReturn(new StringStream($arguments[0]));
+                              ->willReturn(new StringStream((string) $arguments[0]));
             return $optimizedResponse;
         };
 


### PR DESCRIPTION
Currently `EngineTest::testItCanOptimizeAResponse` is failing, because `$optimizedResponse->getBody()` returns a `StringStream` object whose `contents` is also another `StringStream` instance not a string. That is why we're seeing following error in unit test,
```
1) PageExperience\Tests\EngineTest::testItCanOptimizeAResponse
Method PageExperience\Engine\StringStream::__toString() must return a string value

/home/runner/work/px-toolbox-php/px-toolbox-php/tests/EngineTest.php:87
home/runner/work/px-toolbox-php/px-toolbox-php/vendor/phpunit/phpunit/phpunit:51
```

This PR fixes this issue.