### PR TITLE
Add diagrams to test Mermaid.js integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,48 @@ The project is currently in its very early stages, with the main focus lying on 
 
 The initial end-user integration this library is being coded against is the [PX Plugin for WordPress](https://github.com/ampproject/amp-wp).
 
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+graph
+    subgraph pxwp[px-wp]
+        rest[REST API]
+        devtools[Developer Tools]
+
+        devtools -.-> rest
+    end
+
+    subgraph pxtb[px-toolbox-php]
+        pxe[PX Engine]
+    end
+
+    subgraph amptb[amp-toolbox-php]
+        sanitizer[Sanitizer]
+        validator[Validator]
+        optimizer[Optimizer]
+        linter[Linter]
+        spec[AMP Spec]
+
+        sanitizer -.-> spec
+        validator -.-> spec
+        optimizer -.-> spec
+    end
+
+    pxe -.-> sanitizer
+    pxe -.-> validator
+    pxe -.-> optimizer
+    pxe -.-> linter
+
+    rest -.-> pxe
+    devtools -.-> pxe
+
+classDef cplugin fill:#33aa00,stroke:#002080,stroke-width:1px,color:#fff;
+classDef cpx fill:#9955f0,stroke:#002080,stroke-width:1px,color:#fff;
+classDef camp fill:#005af0,stroke:#002080,stroke-width:1px,color:#fff;
+class rest,devtools cplugin;
+class pxe,psi cpx;
+class sanitizer,validator,optimizer,linter,spec camp;
+```
+
 The roadmap will be further fleshed out as we approach the first feature-complete release. 
 
 <p align="right">(<a href="#top">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ Currently included in the toolbox:
 * [**PageSpeed Insights API** - API wrapper for PHP to run audits through the Google PageSpeed Insights API.](/docs/psi/README.md#readme)
 * [**PX CLI tool** - `px` binary to run the above tooling through the console.](/docs/px/README.md#readme)
 
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+graph
+    subgraph PXT[PX Toolbox]
+
+        PSI[<strong>PageSpeed Insights API Client</strong><br><br>API wrapper for PHP to run audits through<br>the Google PageSpeed Insights API]
+        PXE[<strong>Page Experience Engine</strong><br><br>Higher-level library that aggregates and<br>normalizes multiple tools to provide<br>analysis and optimization functionality]
+        PX[<strong>PX CLI Tool</strong><br><br>Console <code>px</code> binary to run the<br>PX Toolbox tools through the CLI]
+
+        PX --provides CLI interface for--> PSI
+        PX --provides CLI interface for--> PXE
+        PSI --powers audits in--> PXE
+    end
+
+classDef package fill:#005af0,stroke:#002080,stroke-width:1px,color:#fff;
+class PX,PXE,PSI package;
+
+click PX "/docs/px/README.md" "Documentation for the PX CLI Tool"
+click PSI "/docs/psi/README.md" "Documentation for the PageSpeed Insights API Client"
+click PXE "/docs/pxe/README.md" "Documentation for the Page Experience Engine"
+```
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ## Getting Started

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,25 @@ Click on one of the entries below to learn more about that sub-project:
 * [**Page Experience Engine** - Higher-level library that aggregates and normalizes multiple tools to provide analysis and optimization functionality.](/docs/pxe/README.md#readme)
 * [**PageSpeed Insights API** - API wrapper for PHP to run audits through the Google PageSpeed Insights API.](/docs/psi/README.md#readme)
 * [**PX CLI tool** - `px` binary to run the above tooling through the console.](/docs/px/README.md#readme)
+
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+graph
+    subgraph PXT[PX Toolbox]
+
+        PSI[<strong>PageSpeed Insights API Client</strong><br><br>API wrapper for PHP to run audits through<br>the Google PageSpeed Insights API]
+        PXE[<strong>Page Experience Engine</strong><br><br>Higher-level library that aggregates and<br>normalizes multiple tools to provide<br>analysis and optimization functionality]
+        PX[<strong>PX CLI Tool</strong><br><br>Console <code>px</code> binary to run the<br>PX Toolbox tools through the CLI]
+
+        PX --provides CLI interface for--> PSI
+        PX --provides CLI interface for--> PXE
+        PSI --powers audits in--> PXE
+    end
+
+classDef package fill:#005af0,stroke:#002080,stroke-width:1px,color:#fff;
+class PX,PXE,PSI package;
+
+click PX "/px/README.md" "Documentation for the PX CLI Tool"
+click PSI "/psi/README.md" "Documentation for the PageSpeed Insights API Client"
+click PXE "/pxe/README.md" "Documentation for the Page Experience Engine"
+```

--- a/docs/px/README.md
+++ b/docs/px/README.md
@@ -38,6 +38,30 @@ The `<url>` needs to be replaced with the URL of the web page you want to audit.
 
 > Note: Currently the `--json` flag needs to be used _before_ the `<url>` argument due to a limitation in the CLI parsing algorithm. This will be fixed in a future patch.  
 
+## Page Experience Engine Optimization (`optimize`)
+
+The page experience optimization can be run with the following command:
+
+```sh
+bin/px optimize <file>
+```
+
+The `<file>` needs to be replaced with the filename/file path of the file you want to optimize. You can use the special filename `-` to let the tool read from STDIN instead.
+
+The optimized output will be printed to STDOUT and can be redirected into a new file as needed.
+
+### Examples
+
+```sh
+# Optimize a file called input.html and store the optimized result in a file called output.html
+bin/px optimize input.html > output.html
+```
+
+```sh
+# Optimize the Google.com homepage and store the optimized result in a file called output.html
+curl https://www.google.com/ | bin/px optimize - > output.html
+```
+
 ## PageSpeed Insights API Audit (`psi`)
 
 An audit via the PageSpeed Insights API can be requested with the following command:


### PR DESCRIPTION
This PR adds a few diagrams to the docs to test whether the Mermaid.js integration in GitHub works as epxected.