### PR TITLE
Adapt tooling to include PSI API data outside of the embedded Lighthouse data

### DIFF
--- a/default-toolstack.json
+++ b/default-toolstack.json
@@ -1,5 +1,5 @@
 {
   "PageExperience\\Engine\\Tool\\AmpOptimizer": [],
   "PageExperience\\Engine\\Tool\\AmpValidator": [],
-  "PageExperience\\Engine\\Tool\\Lighthouse": []
+  "PageExperience\\Engine\\Tool\\PageSpeedInsights": []
 }

--- a/src/Engine/Tool/PageSpeedInsights.php
+++ b/src/Engine/Tool/PageSpeedInsights.php
@@ -10,15 +10,15 @@ use PageExperience\Engine\ConfigurationProfile;
 use PageExperience\Engine\Context;
 use PageExperience\Engine\Exception\MissingResultDataKey;
 use PageExperience\Engine\Exception\ToolRulesetMismatch;
-use PageExperience\Engine\Tool\Lighthouse\Ruleset;
+use PageExperience\Engine\Tool\PageSpeedInsights\Ruleset;
 use PageExperience\PageSpeed\PageSpeedInsightsApi;
 
 /**
- * Lighthouse abstraction as a page experience tool.
+ * PageSpeedInsights abstraction as a page experience tool.
  *
  * @package ampproject/px-toolbox
  */
-final class Lighthouse implements AnalysisTool, Configurable
+final class PageSpeedInsights implements AnalysisTool, Configurable
 {
     /**
      * Array of scored metric keys.
@@ -38,7 +38,7 @@ final class Lighthouse implements AnalysisTool, Configurable
      *
      * @var string
      */
-    const NAME = 'lighthouse';
+    const NAME = 'page-speed-insights';
 
     /**
      * Context key under which to store the lighthouse audit in the context.
@@ -62,7 +62,7 @@ final class Lighthouse implements AnalysisTool, Configurable
     private $toolRuleset;
 
     /**
-     * Instantiate a Lighthouse tool instance.
+     * Instantiate a PageSpeedInsights tool instance.
      *
      * @param RemoteGetRequest $remoteRequest Remote request handler instance to use.
      */

--- a/src/Engine/Tool/PageSpeedInsights/Ruleset.php
+++ b/src/Engine/Tool/PageSpeedInsights/Ruleset.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace PageExperience\Engine\Tool\Lighthouse;
+namespace PageExperience\Engine\Tool\PageSpeedInsights;
 
 use Exception;
 use PageExperience\Engine\ConfigurationProfile;
 use PageExperience\Engine\Exception\FailedToConfigureTool;
 use PageExperience\Engine\Exception\ToolRulesetMismatch;
 use PageExperience\Engine\Tool;
-use PageExperience\Engine\Tool\Lighthouse;
+use PageExperience\Engine\Tool\PageSpeedInsights;
 use PageExperience\Engine\Tool\ToolRuleset;
 
 /**
- * Ruleset for the Lighthouse tool.
+ * Ruleset for the PageSpeedInsights tool.
  *
  * @package ampproject/px-toolbox
  */
@@ -37,7 +37,7 @@ final class Ruleset implements ToolRuleset
      */
     public function getToolName()
     {
-        return Lighthouse::NAME;
+        return PageSpeedInsights::NAME;
     }
 
     /**
@@ -51,7 +51,7 @@ final class Ruleset implements ToolRuleset
      */
     public function configureTool(Tool $tool)
     {
-        if (! $tool instanceof Lighthouse) {
+        if (! $tool instanceof PageSpeedInsights) {
             throw ToolRulesetMismatch::forToolWithToolRuleset($tool, $this);
         }
 
@@ -75,9 +75,9 @@ final class Ruleset implements ToolRuleset
     }
 
     /**
-     * Get the Lighthouse strategy to use.
+     * Get the PageSpeedInsights strategy to use.
      *
-     * @return Strategy Lighthouse strategy to use.
+     * @return Strategy PageSpeedInsights strategy to use.
      */
     public function getStrategy()
     {

--- a/src/Engine/Tool/PageSpeedInsights/Strategy.php
+++ b/src/Engine/Tool/PageSpeedInsights/Strategy.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace PageExperience\Engine\Tool\Lighthouse;
+namespace PageExperience\Engine\Tool\PageSpeedInsights;
 
 use AmpProject\FakeEnum;
 
 /**
- * Strategy to use for the Lighthouse audit.
+ * Strategy to use for the PageSpeedInsights audit.
  *
  * @method static self MOBILE()
  * @method static self DESKTOP()

--- a/tests/Engine/Tool/PageSpeedInsights/RulesetTest.php
+++ b/tests/Engine/Tool/PageSpeedInsights/RulesetTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace PageExperience\Tests\Engine\Tool\Lighthouse;
+namespace PageExperience\Tests\Engine\Tool\PageSpeedInsights;
 
-use PageExperience\Engine\Tool\Lighthouse\Ruleset;
+use PageExperience\Engine\Tool\PageSpeedInsights\Ruleset;
 use PageExperience\Tests\TestCase;
 
 /**
- * Test the Lighthouse Ruleset class.
+ * Test the PageSpeedInsights Ruleset class.
  *
  * @package ampproject/px-toolbox-php
  */

--- a/tests/Engine/Tool/PageSpeedInsightsTest.php
+++ b/tests/Engine/Tool/PageSpeedInsightsTest.php
@@ -3,43 +3,41 @@
 namespace PageExperience\Tests\Engine\Tool;
 
 use AmpProject\RemoteGetRequest;
-use AmpProject\RemoteRequest\StubbedRemoteGetRequest;
 use PageExperience\Engine\Analysis;
 use PageExperience\Engine\ConfigurationProfile;
 use PageExperience\Engine\Context;
-use PageExperience\Engine\Tool\Lighthouse;
+use PageExperience\Engine\Tool\PageSpeedInsights;
 use PageExperience\Tests\ConfiguredStubbedRemoteGetRequest;
 use PageExperience\Tests\TestCase;
 
 /**
- * Test the Lighthouse class.
+ * Test the PageSpeedInsights class.
  *
  * @package ampproject/px-toolbox-php
  */
-final class LighthouseTest extends TestCase
+final class PageSpeedInsightsTest extends TestCase
 {
     public function testItCanBeInstantiated()
     {
         $remoteRequestMock = $this->createMock(RemoteGetRequest::class);
 
-        $lighthouse = new Lighthouse($remoteRequestMock);
+        $pageSpeedInsights = new PageSpeedInsights($remoteRequestMock);
 
-        self::assertInstanceOf(Lighthouse::class, $lighthouse);
+        self::assertInstanceOf(PageSpeedInsights::class, $pageSpeedInsights);
     }
 
     public function testItCanRunAnAudit()
     {
-        $lighthouse = new Lighthouse(ConfiguredStubbedRemoteGetRequest::create());
+        $pageSpeedInsights = new PageSpeedInsights(ConfiguredStubbedRemoteGetRequest::create());
 
         $analysis = $this->createMock(Analysis::class);
         $profile  = new ConfigurationProfile();
         $context  = new Context();
 
-        $ruleset = Lighthouse\Ruleset::fromProfile($profile);
-        $lighthouse->configureWithRuleset($ruleset);
+        $ruleset = PageSpeedInsights\Ruleset::fromProfile($profile);
+        $pageSpeedInsights->configureWithRuleset($ruleset);
 
-        $analysis = $lighthouse->analyze($analysis, 'https://amp-wp.org', $profile, $context);
-
+        $analysis = $pageSpeedInsights->analyze($analysis, 'https://amp-wp.org', $profile, $context);
         $this->assertInstanceOf(Analysis::class, $analysis);
     }
 }

--- a/tests/Engine/ToolStack/ToolStackConfigurationTest.php
+++ b/tests/Engine/ToolStack/ToolStackConfigurationTest.php
@@ -4,7 +4,7 @@ namespace PageExperience\Tests\Engine\ToolStack;
 
 use PageExperience\Engine\Tool\AmpOptimizer;
 use PageExperience\Engine\Tool\AmpValidator;
-use PageExperience\Engine\Tool\Lighthouse;
+use PageExperience\Engine\Tool\PageSpeedInsights;
 use PageExperience\Engine\ToolStack\ToolStackConfiguration;
 use PageExperience\Tests\TestCase;
 
@@ -51,8 +51,8 @@ final class ToolStackConfigurationTest extends TestCase
         self::assertEquals([], $tools[AmpValidator::class]);
         self::assertArrayHasKey(AmpOptimizer::class, $tools);
         self::assertEquals([], $tools[AmpOptimizer::class]);
-        self::assertArrayHasKey(Lighthouse::class, $tools);
-        self::assertEquals([], $tools[Lighthouse::class]);
+        self::assertArrayHasKey(PageSpeedInsights::class, $tools);
+        self::assertEquals([], $tools[PageSpeedInsights::class]);
     }
 
     public function testItCanRegisterNewTools()
@@ -70,8 +70,8 @@ final class ToolStackConfigurationTest extends TestCase
         self::assertEquals([], $tools[AmpValidator::class]);
         self::assertArrayHasKey(AmpOptimizer::class, $tools);
         self::assertEquals([], $tools[AmpOptimizer::class]);
-        self::assertArrayHasKey(Lighthouse::class, $tools);
-        self::assertEquals([], $tools[Lighthouse::class]);
+        self::assertArrayHasKey(PageSpeedInsights::class, $tools);
+        self::assertEquals([], $tools[PageSpeedInsights::class]);
         self::assertArrayHasKey('DummyToolA', $tools);
         self::assertEquals([], $tools['DummyToolA']);
         self::assertArrayHasKey('DummyToolB', $tools);

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -46,8 +46,9 @@ final class EngineTest extends TestCase
     {
         $engine  = new Engine(ConfiguredStubbedRemoteGetRequest::create());
         $profile = new ConfigurationProfile();
+        $analysis = $engine->analyze('https://amp-wp.org', $profile);
 
-        self::assertInstanceOf(Analysis::class, $engine->analyze('https://amp-wp.org', $profile));
+        self::assertInstanceOf(Analysis::class, $analysis);
     }
 
     public function testItCanOptimizeHtml()


### PR DESCRIPTION
Fixes #17 

The goal of this PR is to rename the Lighthouse tool and adapt the new PageSpeedInsight tool to include PSI API data outside of the embedded Lighthouse data. 