### PR TITLE
Add configurations for PX Engine tools

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -8,6 +8,7 @@ use PageExperience\Engine\Analysis\PageExperienceAnalysis;
 use PageExperience\Engine\ConfigurationProfile;
 use PageExperience\Engine\Context;
 use PageExperience\Engine\Rules;
+use PageExperience\Engine\Tool\Configuration;
 use PageExperience\Engine\ToolStack\DefaultToolStackFactory;
 use PageExperience\Engine\ToolStack\ToolStackConfiguration;
 use PageExperience\Engine\ToolStack\ToolStackFactory;
@@ -28,6 +29,13 @@ final class Engine
     private $toolStackFactory;
 
     /**
+     * Configuration for the engine tools.
+     *
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
      * Rules to use for the programmable tools.
      *
      * @var Rules
@@ -39,14 +47,19 @@ final class Engine
      *
      * @param RemoteGetRequest|null $remoteRequest    Optional. Remote request handler instance to use.
      * @param ToolStackFactory|null $toolStackFactory Optional. Tool stack factory instance to use.
+     * @param Configuration|null    $configuration    Optional. Configuration for the engine tools.
      */
-    public function __construct(RemoteGetRequest $remoteRequest = null, ToolStackFactory $toolStackFactory = null)
-    {
+    public function __construct(
+        RemoteGetRequest $remoteRequest = null,
+        ToolStackFactory $toolStackFactory = null,
+        Configuration $configuration = null
+    ) {
         $this->toolStackFactory = $toolStackFactory instanceof ToolStackFactory
             ? $toolStackFactory
             : new DefaultToolStackFactory(
                 ToolStackConfiguration::fromJsonFile(__DIR__ . '/../default-toolstack.json'),
-                $remoteRequest
+                $remoteRequest,
+                $configuration
             );
 
         $this->rules = Rules::createDefaultRules();

--- a/src/Engine/Tool/Configuration.php
+++ b/src/Engine/Tool/Configuration.php
@@ -2,7 +2,7 @@
 
 namespace PageExperience\Engine\Tool;
 
-use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+use PageExperience\Engine\Tool\Exception\UnknownConfigurationKey;
 
 /**
  * Interface for a PX tool configuration object that validates and stores configuration settings.

--- a/src/Engine/Tool/Configuration.php
+++ b/src/Engine/Tool/Configuration.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PageExperience\Engine\Tool;
+
+use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+
+/**
+ * Interface for a PX tool configuration object that validates and stores configuration settings.
+ *
+ * @package ampproject/px-toolbox
+ */
+interface Configuration
+{
+    /**
+     * Key to use for managing the array of active tools.
+     *
+     * @var string
+     */
+    const KEY_TOOLS = 'tools';
+
+    /**
+     * Array of known configuration keys and their default values.
+     *
+     * @var array{tools: string[]}
+     */
+    const DEFAULTS = [
+        self::KEY_TOOLS => self::DEFAULT_TOOLS,
+    ];
+
+    /**
+     * Array of FQCNs of tools to use for the default setup.
+     *
+     * @var string[]
+     */
+    const DEFAULT_TOOLS = [
+        Tool\AmpOptimizer::class,
+        Tool\AmpValidator::class,
+        Tool\PageSpeedInsights::class,
+    ];
+
+    /**
+     * Register a new configuration class to use for a given tool.
+     *
+     * @param string $toolClass   FQCN of the tool to register a configuration class for.
+     * @param string $configurationClass FQCN of the configuration to use.
+     */
+    public function registerConfigurationClass($toolClass, $configurationClass);
+
+    /**
+     * Check whether the configuration has a given setting.
+     *
+     * @param string $key Configuration key to look for.
+     * @return bool Whether the requested configuration key was found or not.
+     */
+    public function has($key);
+
+    /**
+     * Get the value for a given key from the configuration.
+     *
+     * @param string $key Configuration key to get the value for.
+     * @return mixed Configuration value for the requested key.
+     * @throws UnknownConfigurationKey If the key was not found.
+     */
+    public function get($key);
+
+    /**
+     * Get the tool-specific configuration for the requested tool.
+     *
+     * @param string $toolClassName FQCN of the tool to get the configuration for.
+     * @return ToolConfiguration tool-specific configuration.
+     */
+    public function getToolConfiguration($toolClassName);
+}

--- a/src/Engine/Tool/DefaultConfiguration.php
+++ b/src/Engine/Tool/DefaultConfiguration.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace PageExperience\Engine\Tool;
+
+use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
+use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
+use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+
+/**
+ * The default configuration for the PX Engine.
+ *
+ * @package ampproject/px-toolbox
+ */
+class DefaultConfiguration implements Configuration
+{
+    /**
+     * Associative array of already validated configuration settings.
+     *
+     * @var array
+     */
+    protected $configuration;
+
+    /**
+     * Associative array mapping the tool classes to their configuration classes.
+     *
+     * This can be extended by third-parties via:
+     *
+     * @see registerConfigurationClass()
+     *
+     * @var array
+     */
+    protected $toolConfigurationClasses = [];
+
+    /**
+     * Instantiate a Configuration object.
+     *
+     * @param array $configurationData Optional. Associative array of configuration data to use. This will be merged
+     *                                 with the default configuration and take precedence.
+     */
+    public function __construct($configurationData = [])
+    {
+        $this->configuration = array_merge(
+            static::DEFAULTS,
+            $this->validateConfigurationKeys($configurationData)
+        );
+    }
+
+    /**
+     * Register a new configuration class to use for a given tool.
+     *
+     * @param string $toolClass          FQCN of the tool to register a configuration class for.
+     * @param string $configurationClass FQCN of the configuration to use.
+     */
+    public function registerConfigurationClass($toolClass, $configurationClass)
+    {
+        $this->toolConfigurationClasses[$toolClass] = $configurationClass;
+    }
+
+    /**
+     * Validate an array of configuration settings.
+     *
+     * @param array $configurationData Associative array of configuration data to validate.
+     * @return array Associative array of validated configuration data.
+     */
+    protected function validateConfigurationKeys($configurationData)
+    {
+        foreach ($configurationData as $key => $value) {
+            $configurationData[$key] = $this->validate($key, $value);
+        }
+
+        return $configurationData;
+    }
+
+    /**
+     * Validate an individual configuration setting.
+     *
+     * @param string $key   Key of the configuration setting.
+     * @param mixed  $value Value of the configuration setting.
+     * @return mixed Validated value for the provided configuration setting.
+     * @throws InvalidConfigurationValue If the configuration value could not be validated.
+     */
+    protected function validate($key, $value)
+    {
+        switch ($key) {
+            case Configuration::KEY_TOOLS:
+                if (! is_array($value)) {
+                    throw InvalidConfigurationValue::forInvalidValueType(
+                        Configuration::KEY_TOOLS,
+                        'array',
+                        gettype($value)
+                    );
+                }
+
+                foreach ($value as $index => $entry) {
+                    if (! is_string($entry)) {
+                        throw InvalidConfigurationValue::forInvalidSubValueType(
+                            Configuration::KEY_TOOLS,
+                            $index,
+                            'string',
+                            gettype($entry)
+                        );
+                    }
+                }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Check whether the configuration has a given setting.
+     *
+     * @param string $key Configuration key to look for.
+     * @return bool Whether the requested configuration key was found or not.
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->configuration);
+    }
+
+    /**
+     * Get the value for a given key from the configuration.
+     *
+     * @param string $key Configuration key to get the value for.
+     * @return mixed Configuration value for the requested key.
+     * @throws UnknownConfigurationKey If the key was not found.
+     */
+    public function get($key)
+    {
+        if (! array_key_exists($key, $this->configuration)) {
+            throw UnknownConfigurationKey::fromKey($key);
+        }
+
+        return $this->configuration[$key];
+    }
+
+    /**
+     * Get the tool-specific configuration for the requested tool.
+     *
+     * @param string $toolClassName FQCN of the tool to get the configuration for.
+     * @return ToolConfiguration tool-specific configuration.
+     * @throws UnknownConfigurationClass If the tool class was not found.
+     */
+    public function getToolConfiguration($toolClassName)
+    {
+        if (! array_key_exists($toolClassName, $this->toolConfigurationClasses)) {
+            throw UnknownConfigurationClass::fromTransformerClass($toolClassName);
+        }
+
+        $configuration      = $this->has($toolClassName) ? $this->get($toolClassName) : [];
+        $configurationClass = $this->toolConfigurationClasses[$toolClassName];
+
+        return new $configurationClass($configuration);
+    }
+}

--- a/src/Engine/Tool/DefaultConfiguration.php
+++ b/src/Engine/Tool/DefaultConfiguration.php
@@ -2,9 +2,9 @@
 
 namespace PageExperience\Engine\Tool;
 
-use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
-use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
-use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+use PageExperience\Engine\Tool\Exception\InvalidConfigurationValue;
+use PageExperience\Engine\Tool\Exception\UnknownConfigurationClass;
+use PageExperience\Engine\Tool\Exception\UnknownConfigurationKey;
 
 /**
  * The default configuration for the PX Engine.
@@ -143,7 +143,7 @@ class DefaultConfiguration implements Configuration
     public function getToolConfiguration($toolClassName)
     {
         if (! array_key_exists($toolClassName, $this->toolConfigurationClasses)) {
-            throw UnknownConfigurationClass::fromTransformerClass($toolClassName);
+            throw UnknownConfigurationClass::forToolClass($toolClassName);
         }
 
         $configuration      = $this->has($toolClassName) ? $this->get($toolClassName) : [];

--- a/src/Engine/Tool/Exception/InvalidConfigurationValue.php
+++ b/src/Engine/Tool/Exception/InvalidConfigurationValue.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PageExperience\Engine\Tool\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Exception thrown when an invalid configuration value was provided.
+ *
+ * @package ampproject/px-toolbox
+ */
+final class InvalidConfigurationValue extends InvalidArgumentException implements PXEngineToolException
+{
+    /**
+     * Instantiate an InvalidConfigurationValue exception for an invalid value type.
+     *
+     * @param string $key      Key that was invalid.
+     * @param string $expected Value type that was expected.
+     * @param string $actual   Value type that was actually provided.
+     * @return self
+     */
+    public static function forInvalidValueType($key, $expected, $actual)
+    {
+        $message = "The configuration key '{$key}' expected a value of type '{$expected}', got '{$actual}' instead.";
+
+        return new self($message);
+    }
+
+    /**
+     * Instantiate an InvalidConfigurationValue exception for an invalid value type.
+     *
+     * @param string     $key      Key that was invalid.
+     * @param string|int $index    Index of the sub-value that was invalid.
+     * @param string     $expected Value type that was expected.
+     * @param string     $actual   Value type that was actually provided.
+     * @return self
+     */
+    public static function forInvalidSubValueType($key, $index, $expected, $actual)
+    {
+        $message = "The configuration value '{$index}' for the key '{$key}' expected a value of type '{$expected}', "
+                   . "got '{$actual}' instead.";
+
+        return new self($message);
+    }
+
+    /**
+     * Instantiate an InvalidConfigurationValue exception for an unknown value.
+     *
+     * @param string        $key      Key that was invalid.
+     * @param string|int    $index    Index of the sub-value that was invalid.
+     * @param array<string> $accepted Array of acceptable values.
+     * @param string        $actual   Value that was actually provided.
+     * @return self
+     */
+    public static function forUnknownSubValue($key, $index, $accepted, $actual)
+    {
+        $acceptedString = implode(', ', $accepted);
+        $message = "The configuration value '{$index}' for the key '{$key}' expected the value to be one of "
+                   . "[{$acceptedString}], got '{$actual}' instead.";
+
+        return new self($message);
+    }
+}

--- a/src/Engine/Tool/Exception/PXEngineToolException.php
+++ b/src/Engine/Tool/Exception/PXEngineToolException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PageExperience\Engine\Tool\Exception;
+
+use PageExperience\Engine\Exception\PxEngineException;
+
+/**
+ * Marker interface to enable consumers to catch all exceptions for this particular library.
+ *
+ * @package ampproject/px-toolbox
+ */
+interface PXEngineToolException extends PxEngineException
+{
+}

--- a/src/Engine/Tool/Exception/UnknownConfigurationClass.php
+++ b/src/Engine/Tool/Exception/UnknownConfigurationClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PageExperience\Engine\Tool\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Exception thrown when an unknown configuration key was requested.
+ *
+ * @package ampproject/px-toolbox
+ */
+final class UnknownConfigurationClass extends InvalidArgumentException implements PXEngineToolException
+{
+    /**
+     * Instantiate an UnknownConfigurationClass exception for an unknown configuration class.
+     *
+     * @param string $toolClass Key that was unknown.
+     * @return self
+     */
+    public static function forToolClass($toolClass)
+    {
+        $message = "No configuration class was registered for the tool '{$toolClass}'.";
+
+        return new self($message);
+    }
+}

--- a/src/Engine/Tool/Exception/UnknownConfigurationKey.php
+++ b/src/Engine/Tool/Exception/UnknownConfigurationKey.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PageExperience\Engine\Tool\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Exception thrown when an unknown configuration key was requested.
+ *
+ * @package ampproject/px-toolbox
+ */
+final class UnknownConfigurationKey extends InvalidArgumentException implements PXEngineToolException
+{
+    /**
+     * Instantiate an UnknownConfigurationKey exception for an unknown key.
+     *
+     * @param string $key Key that was unknown.
+     * @return self
+     */
+    public static function fromKey($key)
+    {
+        $message = "The configuration does not contain the requested key '{$key}'.";
+
+        return new self($message);
+    }
+
+    /**
+     * Instantiate an UnknownConfigurationKey exception for an unknown tool configuration key.
+     *
+     * @param string $tool Tool class or identifier.
+     * @param string $key  Key that was unknown.
+     * @return self
+     */
+    public static function fromToolKey($tool, $key)
+    {
+        $parts   = explode('\\', $tool);
+        $tool    = array_pop($parts);
+        $message = "The configuration of the tool '{$tool}' does not contain "
+                    . "the requested key '{$key}'.";
+
+        return new self($message);
+    }
+}

--- a/src/Engine/Tool/ToolConfiguration.php
+++ b/src/Engine/Tool/ToolConfiguration.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PageExperience\Engine\Tool;
+
+use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+
+/**
+ * Interface for a PX tool that validates and stores configuration settings for an individual engine tool.
+ *
+ * @package ampproject/px-toolbox
+ */
+interface ToolConfiguration
+{
+    /**
+     * Get the value for a given key.
+     *
+     * The key is assumed to exist and will throw an exception if it can't be retrieved.
+     * This means that all configuration entries should come with a default value.
+     *
+     * @param string $key Key of the configuration entry to retrieve.
+     * @return mixed Value stored under the given configuration key.
+     * @throws UnknownConfigurationKey If an unknown key was provided.
+     */
+    public function get($key);
+
+    /**
+     * Get an array of configuration entries for this tool configuration.
+     *
+     * @return array Associative array of configuration entries.
+     */
+    public function toArray();
+}

--- a/src/Engine/Tool/ToolConfiguration.php
+++ b/src/Engine/Tool/ToolConfiguration.php
@@ -2,7 +2,7 @@
 
 namespace PageExperience\Engine\Tool;
 
-use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+use PageExperience\Engine\Tool\Exception\UnknownConfigurationKey;
 
 /**
  * Interface for a PX tool that validates and stores configuration settings for an individual engine tool.


### PR DESCRIPTION
Fixes #18 

The goal of this PR is to create a configuration system for the individual PXE tools, that can be provided via the PX Engine when it is instantiated. With this system we can create our own configuration and provide it to the Engine like this,
```php
<?php 

use PageExperience\Engine;
use PageExperience\Engine\Tool\DefaultConfiguration;

class MyConfiguration extends DefaultConfiguration
{
    // extend the default configuration...
}

$pxEngine = new Engine(null, null, new MyConfiguration());
```

Then in a tool class we can use the configuration like following,
```php
<?php 

use AmpProject\RemoteGetRequest;
use PageExperience\Engine\Tool\Configurable;
use PageExperience\Engine\Tool\OptimizationTool;
use PageExperience\Engine\Tool\ToolConfiguration;

final class MyPXETool implements OptimizationTool, Configurable 
{
    public function __construct(RemoteGetRequest $remoteRequest, ToolConfiguration $configuration)
    {
        $this->remoteRequest = $remoteRequest;
        $this->configuration = $configuration;
    }       
}
```
---
### Todo:
- [x] Add configuration classes
- [x] Add exception classes
- [ ] Add testing